### PR TITLE
Use stdin as post data

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -32,7 +33,16 @@ func main() {
 	}
 
 	//Form JSON payload to send to Slack
-	json := `{"text": "` + args + `"}`
+	var json string
+	if buf, err := ioutil.ReadAll(os.Stdin); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	} else if len(buf) > 0 {
+		json = string(buf)
+	} else {
+		json = `{"text": "` + args + `"}`
+	}
+
 	//Post JSON payload to the Webhook URL
 	client := http.Client{}
 	req, err := http.NewRequest("POST", os.Getenv("SLACK_WEBHOOK_URL"), bytes.NewBufferString(json))

--- a/main.go
+++ b/main.go
@@ -25,21 +25,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	// input send text
-	args := strings.Join(os.Args[1:], " ")
-	if args == "" {
-		fmt.Fprintln(os.Stdout, "usage: slack-notifier <TEXT>")
-		os.Exit(0)
-	}
-
 	//Form JSON payload to send to Slack
 	var json string
-	if buf, err := ioutil.ReadAll(os.Stdin); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	} else if len(buf) > 0 {
-		json = string(buf)
+	args := strings.Join(os.Args[1:], " ")
+	if args == "" {
+		// use stdin as post data
+		if buf, err := ioutil.ReadAll(os.Stdin); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		} else if len(buf) > 0 {
+			json = string(buf)
+		} else {
+			fmt.Fprintln(os.Stdout, "usage: slack-notifier <TEXT>")
+			os.Exit(0)
+		}
 	} else {
+		// use os.Args as post message
 		json = `{"text": "` + args + `"}`
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,15 +30,16 @@ func main() {
 	args := strings.Join(os.Args[1:], " ")
 	if args == "" {
 		// use stdin as post data
-		if buf, err := ioutil.ReadAll(os.Stdin); err != nil {
+		buf, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
-		} else if len(buf) > 0 {
-			json = string(buf)
-		} else {
+		}
+		if len(buf) == 0 {
 			fmt.Fprintln(os.Stderr, "usage: slack-notifier <TEXT>")
 			os.Exit(1)
 		}
+		json = string(buf)
 	} else {
 		// use os.Args as post message
 		json = `{"text": "` + args + `"}`

--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func main() {
 		} else if len(buf) > 0 {
 			json = string(buf)
 		} else {
-			fmt.Fprintln(os.Stdout, "usage: slack-notifier <TEXT>")
-			os.Exit(0)
+			fmt.Fprintln(os.Stderr, "usage: slack-notifier <TEXT>")
+			os.Exit(1)
 		}
 	} else {
 		// use os.Args as post message


### PR DESCRIPTION
## WHY

I want to use [attachments](https://api.slack.com/docs/message-attachments), but current slack-notifier can use [basic formatting](https://api.slack.com/docs/message-formatting) only.

## WHAT

If args is empty, accepts post data from stdin.

```
mbp-bgpat:slack-notifier bgpat$ bin/slack-notifier hello
mbp-bgpat:slack-notifier bgpat$ bin/slack-notifier
{"attachments":[{"color":"#ff0000","text":"foo"}]}
mbp-bgpat:slack-notifier bgpat$ bin/slack-notifier
usage: slack-notifier <TEXT>
```

<img width="315" alt="image" src="https://cloud.githubusercontent.com/assets/6045753/23647333/b057efdc-0358-11e7-8dd2-2e388e17781c.png">